### PR TITLE
Search and destroy refs and commits

### DIFF
--- a/find_commits.zsh
+++ b/find_commits.zsh
@@ -87,4 +87,20 @@ if (( matches_found == 0 )); then
   exit 0
 fi
 
+# 6) Search each repo in matched_repos for refs that contain each found commit
+for repo in "${matched_repos[@]}"; do
+  echo "Searching for refs in $repo..."
+  refs=$(sudo -u "$currentUser" git -C "$repo" for-each-ref --contains "$full_sha" --format='%(refname:short)' 2>/dev/null)
+  if [[ -n "$refs" ]]; then
+    echo "  refs containing this commit:"
+    while IFS= read -r ref; do
+      echo "    $ref"
+    done <<< "$refs"
+    exit 0
+  else
+    echo "  no refs found containing this commit"
+    exit 1
+  fi
+done
+
 exit 1

--- a/find_commits.zsh
+++ b/find_commits.zsh
@@ -63,6 +63,7 @@ hashes=("${(@s/,/)4}")
 
 # 5) Search each provided SHA across all repos
 matches_found=0
+matched_repos=()
 
   for sha in "${hashes[@]}"; do
     echo "Looking for $sha..."
@@ -73,6 +74,10 @@ matches_found=0
         echo "  repo=$repo"
         echo ""
         matches_found=1
+        # Add repo to matched_repos array if not already present
+        if [[ ! " ${matched_repos[*]} " =~ " $repo " ]]; then
+            matched_repos+=("$repo")
+        fi
     fi
   done
 done


### PR DESCRIPTION
For those repos that have a bad commit:
1. Find all refs that point to that commit (directly or otherwise)
2. Delete those refs
3. Run garbage collection with `--prune=now` to remove the orphaned commits

Doesn't work if the target commit hash is present in the reflog. We could try cleaning the reflog, but I'm not sure it's necessary, since the commit will only be in there if the dev checked out the bad branch. It seems to be do-able, though.

## QA Steps
- `cd` to your target repo
- `git fetch`
- Pick a new origin-tracking branch from the output
- `git rev-parse origin/foobar`
- `cd` back to this repo
- Use the commit output by `git rev-parse` to run the script in this repo `./find_commits.zsh 0 0 0 "abcd1234"`
- Running `git show abcd1234` in the target repo should show `fatal: bad object`

References:
- ["Search and Destroy" - The Stooges](https://youtu.be/TUkUc2O6EAk?si=A43xa8bC9h0ac2v7)